### PR TITLE
fix JSONDecodeError when parsing invalid json in request body

### DIFF
--- a/aiohttp_apispec/middlewares.py
+++ b/aiohttp_apispec/middlewares.py
@@ -15,7 +15,10 @@ def aoihttp_apispec_middleware(request: web.Request,
     kwargs = {}
     for schema in handler.__schemas__:
         if schema['location'] == 'body':
-            request_data = yield from request.json(loads=json_worker.loads)
+            try:
+                request_data = yield from request.json(loads=json_worker.loads)
+            except json.decoder.JSONDecodeError as e:
+                request_data = {}
         else:
             request_data = request.query
         data, errors = schema['schema'].load(data=request_data)

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -1,6 +1,6 @@
 import pytest
 from aiohttp import web
-
+from yarl import URL
 from aiohttp_apispec import docs
 
 
@@ -22,7 +22,7 @@ class TestDocumentation:
         return app
 
     def test_app_swagger_url(self, aiohttp_app):
-        assert '/api/docs/api-docs' in [route.url() for route in aiohttp_app.router.routes()]
+        assert URL('/api/docs/api-docs') in [route.url_for() for route in aiohttp_app.router.routes()]
 
     def test_app_swagger_json(self, aiohttp_app, doc):
         docs = aiohttp_app['swagger_dict']


### PR DESCRIPTION
fix JSONDecodeError when parsing invalid json in request body
fix test 'test_app_swagger_url' (attribuerror url)