### PR TITLE
Release candidate for 0.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "nightly"
 install:
   - pip install -r dev-requirements.txt
 script:

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ===============
-aoihttp-apispec
+aiohttp-apispec
 ===============
 
 .. image:: https://badge.fury.io/py/aiohttp-apispec.svg
@@ -43,7 +43,7 @@ Quickstart
     @docs(tags=['mytag'],
           summary='Test method summary',
           description='Test method description')
-    @use_kwargs(RequestSchema())
+    @use_kwargs(RequestSchema(strict=True))
     @marshal_with(ResponseSchema(), 200)
     async def index(request):
         return web.json_response({'msg': 'done', 'data': {}})
@@ -69,11 +69,11 @@ Adding validation middleware
 .. code-block:: python
 
 
-    from aiohttp_apispec import aoihttp_apispec_middleware
+    from aiohttp_apispec import aiohttp_apispec_middleware
 
     ...
 
-    app.middlewares.append(aoihttp_apispec_middleware)
+    app.middlewares.append(aiohttp_apispec_middleware)
     # now you can access all validated data in route from dict request.data
 
 

--- a/aiohttp_apispec/decorators.py
+++ b/aiohttp_apispec/decorators.py
@@ -43,6 +43,8 @@ def use_kwargs(schema, **kwargs):
 
 
 def marshal_with(schema, code=200, required=False):
+    if callable(schema):
+        schema = schema()
 
     def wrapper(func):
         if not hasattr(func, '__apispec__'):

--- a/aiohttp_apispec/middlewares.py
+++ b/aiohttp_apispec/middlewares.py
@@ -7,9 +7,9 @@ from aiohttp import web
 @web.middleware
 @asyncio.coroutine
 def aoihttp_apispec_middleware(request: web.Request,
-                                     handler,
-                                     json_worker=json,
-                                     error_handler=None) -> web.Response:
+                               handler,
+                               json_worker=json,
+                               error_handler=None) -> web.Response:
     if not hasattr(handler, '__schemas__'):
         return (yield from handler(request))
     kwargs = {}

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,7 @@
 aiohttp
 apispec
 marshmallow
+webargs
 pytest
 pytest-cov
 codecov

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     install_requires=[
         'aiohttp',
         'apispec',
+        'webargs'
     ],
     license='MIT',
     url='https://github.com/maximdanilchenko/aiohttp-apispec',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,18 @@ def request_schema():
         id = fields.Int()
         name = fields.Str(description='name')
         bool_field = fields.Bool()
-    return RequestSchema()
+        list_field = fields.List(fields.Int())
+    return RequestSchema(strict=True)
+
+
+@pytest.fixture
+def request_callable_schema():
+    class RequestSchema(Schema):
+        id = fields.Int()
+        name = fields.Str(description='name')
+        bool_field = fields.Bool()
+        list_field = fields.List(fields.Int())
+    return RequestSchema
 
 
 @pytest.fixture

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -11,7 +11,7 @@ class TestViewDecorators:
         @docs(tags=['mytag'],
               summary='Test method summary',
               description='Test method description')
-        @use_kwargs(request_schema, location='query')
+        @use_kwargs(request_schema, locations=['query'])
         @marshal_with(response_schema, 200)
         def index(request, **data):
             return web.json_response({'msg': 'done', 'data': {}})
@@ -28,7 +28,7 @@ class TestViewDecorators:
 
     @pytest.fixture
     def aiohttp_view_kwargs(self, request_schema):
-        @use_kwargs(request_schema, location='query')
+        @use_kwargs(request_schema, locations=['query'])
         def index(request, **data):
             return web.json_response({'msg': 'done', 'data': {}})
         return index
@@ -53,18 +53,21 @@ class TestViewDecorators:
         assert hasattr(aiohttp_view_kwargs, '__apispec__')
         assert hasattr(aiohttp_view_kwargs, '__schemas__')
         assert aiohttp_view_kwargs.__schemas__ == [{'schema': request_schema,
-                                                    'location': 'query'}]
+                                                    'locations': ['query']}]
         for param in ('parameters', 'responses', 'docked'):
             assert param in aiohttp_view_kwargs.__apispec__
 
     def test_use_kwargs_parameters(self, aiohttp_view_kwargs):
         parameters = aiohttp_view_kwargs.__apispec__['parameters']
-        print(parameters)
+        print(sorted(parameters, key=lambda x: x['name']))
         assert sorted(parameters, key=lambda x: x['name']) == [
             {'in': 'query', 'name': 'bool_field',
              'required': False, 'type': 'boolean'},
             {'in': 'query', 'name': 'id',
              'required': False, 'type': 'integer', 'format': 'int32'},
+            {'in': 'query', 'name': 'list_field',
+             'required': False, 'collectionFormat': 'multi',
+             'type': 'array', 'items': {'type': 'integer', 'format': 'int32'}},
             {'in': 'query', 'name': 'name',
              'required': False, 'type': 'string', 'description': 'name'}
         ]

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -30,7 +30,7 @@ class TestDocumentation:
         assert docs['info']['title'] == 'My Documentation'
         assert docs['info']['version'] == 'v1'
         assert docs['paths']['/v1/test']['get'] == {
-            'parameters': [{'in': 'path', 'name': None, 'required': True, 'type': 'string'}],
+            'parameters': [],
             'responses': {},
             'tags': ['mytag'],
             'summary': 'Test method summary',

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -8,9 +8,9 @@ from aiohttp_apispec import use_kwargs, aoihttp_apispec_middleware
 
 class TestViewDecorators:
 
-    @pytest.fixture
-    def aiohttp_app(self, doc, request_schema, loop, test_client):
-        @use_kwargs(request_schema, location='query')
+    @pytest.fixture(params=[{'locations': ['query']}, {'location': 'query'}])
+    def aiohttp_app(self, doc, request_schema, request_callable_schema, loop, test_client, request):
+        @use_kwargs(request_schema, **request.param)
         def handler_get(request):
             print(request.data)
             return web.json_response({'msg': 'done', 'data': {}})
@@ -20,8 +20,18 @@ class TestViewDecorators:
             print(request.data)
             return web.json_response({'msg': 'done', 'data': {}})
 
+        @use_kwargs(request_callable_schema)
+        def handler_post_callable_schema(request):
+            print(request.data)
+            return web.json_response({'msg': 'done', 'data': {}})
+
         @use_kwargs(request_schema)
-        def handler_echo(request):
+        def handler_post_echo(request):
+            return web.json_response(request.data)
+
+        @use_kwargs(request_schema, **request.param)
+        def handler_get_echo(request):
+            print(request.data)
             return web.json_response(request.data)
 
         def other(request):
@@ -30,11 +40,12 @@ class TestViewDecorators:
         app = web.Application()
         app.router.add_routes([
             web.get('/v1/test', handler_get),
-            web.post('/v1/test', handler_post)])
-        # app.router.add_get('/v1/test', handler_get)
-        # app.router.add_post('/v1/test', handler_post)
-        app.router.add_get('/v1/other', other)
-        app.router.add_post('/v1/echo', handler_echo)
+            web.post('/v1/test', handler_post),
+            web.post('/v1/test_call', handler_post_callable_schema),
+            web.get('/v1/other', other),
+            web.get('/v1/echo', handler_get_echo),
+            web.post('/v1/echo', handler_post_echo),
+        ])
         app.middlewares.append(aoihttp_apispec_middleware)
         doc.register(app)
 
@@ -46,7 +57,7 @@ class TestViewDecorators:
         assert res.status == 200
 
     @asyncio.coroutine
-    def test_response_400_get(self, aiohttp_app):
+    def test_response_422_get(self, aiohttp_app):
         res = yield from aiohttp_app.get('/v1/test', params={'id': 'string', 'name': 'max'})
         assert res.status == 400
 
@@ -56,7 +67,12 @@ class TestViewDecorators:
         assert res.status == 200
 
     @asyncio.coroutine
-    def test_response_400_post(self, aiohttp_app):
+    def test_response_200_post_callable_schema(self, aiohttp_app):
+        res = yield from aiohttp_app.post('/v1/test_call', json={'id': 1, 'name': 'max'})
+        assert res.status == 200
+
+    @asyncio.coroutine
+    def test_response_422_post(self, aiohttp_app):
         res = yield from aiohttp_app.post('/v1/test', json={'id': 'string', 'name': 'max'})
         assert res.status == 400
 
@@ -66,9 +82,21 @@ class TestViewDecorators:
         assert res.status == 200
 
     @asyncio.coroutine
-    def test_response_data(self, aiohttp_app):
-        res = yield from aiohttp_app.post('/v1/echo', json={'id': 1, 'name': 'max'})
-        assert (yield from res.json()) == {'id': 1, 'name': 'max'}
+    def test_response_data_post(self, aiohttp_app):
+        res = yield from aiohttp_app.post('/v1/echo', json={'id': 1, 'name': 'max',
+                                                            'list_field': [1, 2, 3, 4]})
+        assert (yield from res.json()) == {'id': 1, 'name': 'max', 'list_field': [1, 2, 3, 4]}
+
+    @asyncio.coroutine
+    def test_response_data_get(self, aiohttp_app):
+        res = yield from aiohttp_app.get('/v1/echo', params=[('id', '1'),
+                                                             ('name', 'max'),
+                                                             ('bool_field', '0'),
+                                                             ('list_field', '1'),
+                                                             ('list_field', '2'),
+                                                             ('list_field', '3'),
+                                                             ('list_field', '4')])
+        assert (yield from res.json()) == {'id': 1, 'name': 'max', 'bool_field': False, 'list_field': [1, 2, 3, 4]}
 
     @asyncio.coroutine
     def test_swagger_handler_200(self, aiohttp_app):

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -13,18 +13,23 @@ class TestViewDecorators:
     def aiohttp_app(self, doc, request_schema, loop, test_client):
         @use_kwargs(request_schema, location='query')
         def handler_get(request):
+            print(request.data)
             return web.json_response({'msg': 'done', 'data': {}})
 
         @use_kwargs(request_schema)
         def handler_post(request):
+            print(request.data)
             return web.json_response({'msg': 'done', 'data': {}})
 
         def other(request):
             return web.Response()
 
         app = web.Application()
-        app.router.add_get('/v1/test', handler_get)
-        app.router.add_post('/v1/test', handler_post)
+        app.router.add_routes([
+            web.get('/v1/test', handler_get),
+            web.post('/v1/test', handler_post)])
+        # app.router.add_get('/v1/test', handler_get)
+        # app.router.add_post('/v1/test', handler_post)
         app.router.add_get('/v1/other', other)
         app.middlewares.append(aoihttp_apispec_middleware)
         doc.register(app)


### PR DESCRIPTION
Changes:
- webargs validation
- fields.List supporting (because of webargs) and other benefits of webargs validation
- possibility of using schemas like so (not callable):
    ```python 
    @use_kwargs(RequestSchema)  # insteed of RequestSchema()
    async def index(request):
        return web.json_response({'msg': 'done', 'data': {}})
    ```