### PR TITLE
correct request object editing (like suggested in aiohttp docs)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,8 +57,8 @@ Quickstart
                          version='v1',
                          url='/api/docs/api-docs')
 
-    # add startup method to form swagger json
-    app.on_startup.append(doc.register)
+    # add method to form swagger json:
+    doc.register(app)  # we should do it only after all routes are added to router!
 
     # now we can find it on 'http://localhost:8080/api/docs/api-docs'
     web.run_app(app)
@@ -74,7 +74,7 @@ Adding validation middleware
     ...
 
     app.middlewares.append(aiohttp_apispec_middleware)
-    # now you can access all validated data in route from dict request.data
+    # now you can access all validated data in route from request['data']
 
 
 Build swagger client with aiohttp_swagger library
@@ -86,6 +86,6 @@ Build swagger client with aiohttp_swagger library
 
     ...
 
-    doc.register(app) # we should do it only after all routes are added to router!
+    doc.register(app)
     setup_swagger(app=app, swagger_url='/api/doc', swagger_info=app['swagger_dict'])
     # now we can access swagger client on /api/doc url

--- a/aiohttp_apispec/middlewares.py
+++ b/aiohttp_apispec/middlewares.py
@@ -22,7 +22,7 @@ def aiohttp_apispec_middleware(request: web.Request,
         if data:
             kwargs.update(data)
     kwargs.update(request.match_info)
-    request.data = kwargs
+    request['data'] = request.data = kwargs  # request.data will be removed since 1.0.0
     return (yield from handler(request))
 
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 setup(
     name='aiohttp-apispec',
-    version='0.2.0',
+    version='0.3.1',
     description='Build and document REST APIs with aiohttp and apispec',
     long_description=read('README.rst'),
     author='Danilchenko Maksim',

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -27,10 +27,15 @@ class TestViewDecorators:
 
         @use_kwargs(request_schema)
         def handler_post_echo(request):
-            return web.json_response(request.data)
+            return web.json_response(request['data'])
 
         @use_kwargs(request_schema, **request.param)
         def handler_get_echo(request):
+            print(request.data)
+            return web.json_response(request['data'])
+
+        @use_kwargs(request_schema, **request.param)
+        def handler_get_echo_old_data(request):
             print(request.data)
             return web.json_response(request.data)
 
@@ -44,6 +49,7 @@ class TestViewDecorators:
             web.post('/v1/test_call', handler_post_callable_schema),
             web.get('/v1/other', other),
             web.get('/v1/echo', handler_get_echo),
+            web.get('/v1/echo_old', handler_get_echo_old_data),
             web.post('/v1/echo', handler_post_echo),
         ])
         app.middlewares.append(aiohttp_apispec_middleware)
@@ -86,6 +92,17 @@ class TestViewDecorators:
         res = yield from aiohttp_app.post('/v1/echo', json={'id': 1, 'name': 'max',
                                                             'list_field': [1, 2, 3, 4]})
         assert (yield from res.json()) == {'id': 1, 'name': 'max', 'list_field': [1, 2, 3, 4]}
+
+    @asyncio.coroutine
+    def test_response_data_get_old_data(self, aiohttp_app):
+        res = yield from aiohttp_app.get('/v1/echo_old', params=[('id', '1'),
+                                                                 ('name', 'max'),
+                                                                 ('bool_field', '0'),
+                                                                 ('list_field', '1'),
+                                                                 ('list_field', '2'),
+                                                                 ('list_field', '3'),
+                                                                 ('list_field', '4')])
+        assert (yield from res.json()) == {'id': 1, 'name': 'max', 'bool_field': False, 'list_field': [1, 2, 3, 4]}
 
     @asyncio.coroutine
     def test_response_data_get(self, aiohttp_app):


### PR DESCRIPTION
As mentioned in [docs](https://docs.aiohttp.org/en/stable/web_advanced.html#data-sharing-aka-no-singletons-please) we shoul use web.Request instance like container object.

P.S.
On this line:
```python
request['data'] = request.data = kwargs
```
request['data'] and request.data are the same objects in memory (with one id). So this dublicating is not affecting speed or memory usage.