### PR TITLE
Fix non-valid path/response object fields

### DIFF
--- a/aiohttp_apispec/decorators.py
+++ b/aiohttp_apispec/decorators.py
@@ -89,7 +89,7 @@ def use_kwargs(schema, locations=None, **kwargs):
     return wrapper
 
 
-def marshal_with(schema, code=200, required=False):
+def marshal_with(schema, code=200, required=False, description=None):
     """
     Add response info into the swagger spec
 
@@ -122,6 +122,8 @@ def marshal_with(schema, code=200, required=False):
         # https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#responseObject
         valid_response_fields = ('schema', 'description', 'headers', 'examples')
         parameters = {k: v for k, v in raw_parameters.items() if k in valid_response_fields}
+        if description:
+            parameters['description'] = description
         func.__apispec__['responses']['%s' % code] = parameters
         return func
 

--- a/aiohttp_apispec/decorators.py
+++ b/aiohttp_apispec/decorators.py
@@ -1,5 +1,7 @@
 from apispec.ext.marshmallow.swagger import schema2parameters
 
+VALID_RESPONSE_FIELDS = {'schema', 'description', 'headers', 'examples'}
+
 
 def docs(**kwargs):
     """
@@ -109,6 +111,8 @@ def marshal_with(schema, code=200, required=False, description=None):
         async def index(request):
             return web.json_response({'msg': 'done', 'data': {}})
 
+    :param description:
+    :param required:
     :param schema: :class:`Schema <marshmallow.Schema>` class or instance
     :param code: HTTP response code
     """
@@ -120,8 +124,7 @@ def marshal_with(schema, code=200, required=False, description=None):
             func.__apispec__ = {'parameters': [], 'responses': {}, 'docked': {}}
         raw_parameters = schema2parameters(schema, required=required)[0]
         # https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#responseObject
-        valid_response_fields = ('schema', 'description', 'headers', 'examples')
-        parameters = {k: v for k, v in raw_parameters.items() if k in valid_response_fields}
+        parameters = {k: v for k, v in raw_parameters.items() if k in VALID_RESPONSE_FIELDS}
         if description:
             parameters['description'] = description
         func.__apispec__['responses']['%s' % code] = parameters

--- a/aiohttp_apispec/decorators.py
+++ b/aiohttp_apispec/decorators.py
@@ -118,9 +118,11 @@ def marshal_with(schema, code=200, required=False):
     def wrapper(func):
         if not hasattr(func, '__apispec__'):
             func.__apispec__ = {'parameters': [], 'responses': {}, 'docked': {}}
-        func.__apispec__['responses']['%s' % code] = schema2parameters(
-            schema, required=required
-        )[0]
+        raw_parameters = schema2parameters(schema, required=required)[0]
+        # https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#responseObject
+        valid_response_fields = ('schema', 'description', 'headers', 'examples')
+        parameters = {k: v for k, v in raw_parameters.items() if k in valid_response_fields}
+        func.__apispec__['responses']['%s' % code] = parameters
         return func
 
     return wrapper

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -100,9 +100,6 @@ class TestViewDecorators:
             assert param in aiohttp_view_marshal.__apispec__
         assert '200' in aiohttp_view_marshal.__apispec__['responses']
         assert aiohttp_view_marshal.__apispec__['responses']['200'] == {
-            'in': 'body',
-            'required': False,
-            'name': 'body',
             'schema': {
                 'type': 'object',
                 'properties': {'data': {'type': 'object'}, 'msg': {'type': 'string'}},


### PR DESCRIPTION
This is a quick-fix for #15:
  - remove non-valid fields returned from `schema2parameters()`
  - add description parameter (which is required for response object) to `@marshal_with` decorator