### PR TITLE
extra parameters for api spec

### DIFF
--- a/aiohttp_apispec/decorators.py
+++ b/aiohttp_apispec/decorators.py
@@ -14,16 +14,16 @@ def docs(**kwargs):
 
         from aiohttp import web
 
-        @docs(tags=['my_tag'],
-              summary='Test method summary',
-              description='Test method description',
-              extra_parameters=[{
-                      'in': 'header',
-                      'name': 'X-Request-ID',
-                      'schema': {'type': 'string', 'format': 'uuid'},
-                      'required': 'true'
-                  }]
-              )
+@docs(tags=['my_tag'],
+      summary='Test method summary',
+      description='Test method description',
+      extra_parameters=[{
+              'in': 'header',
+              'name': 'X-Request-ID',
+              'schema': {'type': 'string', 'format': 'uuid'},
+              'required': 'true'
+          }]
+      )
         async def index(request):
             return web.json_response({'msg': 'done', 'data': {}})
 
@@ -34,7 +34,7 @@ def docs(**kwargs):
         if not hasattr(func, '__apispec__'):
             func.__apispec__ = {'parameters': [], 'responses': {}, 'docked': {}}
         func.__apispec__.update(kwargs)
-        func.__apispec__['parameters'].extend(kwargs['extra_parameters'])
+        func.__apispec__['parameters'].extend(kwargs.get('extra_parameters', []))
         func.__apispec__['docked'] = {'route': False}
         return func
 

--- a/aiohttp_apispec/decorators.py
+++ b/aiohttp_apispec/decorators.py
@@ -16,7 +16,14 @@ def docs(**kwargs):
 
         @docs(tags=['my_tag'],
               summary='Test method summary',
-              description='Test method description')
+              description='Test method description',
+              extra_parameters=[{
+                      'in': 'header',
+                      'name': 'X-Request-ID',
+                      'schema': {'type': 'string', 'format': 'uuid'},
+                      'required': 'true'
+                  }]
+              )
         async def index(request):
             return web.json_response({'msg': 'done', 'data': {}})
 
@@ -27,6 +34,7 @@ def docs(**kwargs):
         if not hasattr(func, '__apispec__'):
             func.__apispec__ = {'parameters': [], 'responses': {}, 'docked': {}}
         func.__apispec__.update(kwargs)
+        func.__apispec__['parameters'].extend(kwargs['extra_parameters'])
         func.__apispec__['docked'] = {'route': False}
         return func
 

--- a/aiohttp_apispec/decorators.py
+++ b/aiohttp_apispec/decorators.py
@@ -33,8 +33,9 @@ def docs(**kwargs):
         kwargs['produces'] = ['application/json']
         if not hasattr(func, '__apispec__'):
             func.__apispec__ = {'parameters': [], 'responses': {}, 'docked': {}}
+        extra_parameters = kwargs.pop('parameters', [])
+        func.__apispec__['parameters'].extend(extra_parameters)
         func.__apispec__.update(kwargs)
-        func.__apispec__['parameters'].extend(kwargs.get('extra_parameters', []))
         func.__apispec__['docked'] = {'route': False}
         return func
 


### PR DESCRIPTION
(Maybe weird) solution for adding custom headers in api spec and make requests in swagger GUI.

Example
```
@docs(tags=['my_tag'],
      summary='Test method summary',
      description='Test method description',
      extra_parameters=[{
              'in': 'header',
              'name': 'X-Request-ID',
              'schema': {'type': 'string', 'format': 'uuid'},
              'required': 'true'
          }]
      )
```