### PR TITLE
Fixed possible duplicated path parameters for GET-based routes

### DIFF
--- a/aiohttp_apispec/aiohttp_apispec.py
+++ b/aiohttp_apispec/aiohttp_apispec.py
@@ -70,16 +70,15 @@ class AiohttpApiSpec:
         if not url_path:
             return None
 
-        view.__apispec__["parameters"].extend(
-            {"in": "path", "name": path_key, "required": True, "type": "string"}
-            for path_key in get_path_keys(url_path)
-        )
         self._update_paths(view.__apispec__, method, url_path)
 
     def _update_paths(self, data: dict, method: str, url_path: str):
-        operations = copy.deepcopy(data)
-
         if method in PATHS:
+            data["parameters"].extend(
+                {"in": "path", "name": path_key, "required": True, "type": "string"}
+                for path_key in get_path_keys(url_path)
+            )
+            operations = copy.deepcopy(data)
             self.spec.add_path(Path(path=url_path, operations={method: operations}))
 
 


### PR DESCRIPTION
If you register a decorated handler route as follows:

```
web.get('/api/v1/resource/{id}/'), resource_handler),
```

the generated API spec will contain two path parameters for `id`. This is because there is a `web.head` route that is generated by aiohttp for the GET-based route by default. The only workaround is to disable head requests by using the `allow_head=False` argument when registering the route. This commit fixes this behaviour.