### PR TITLE
Dont duplicate path properties

### DIFF
--- a/aiohttp_apispec/aiohttp_apispec.py
+++ b/aiohttp_apispec/aiohttp_apispec.py
@@ -74,9 +74,10 @@ class AiohttpApiSpec:
 
     def _update_paths(self, data: dict, method: str, url_path: str):
         if method in PATHS:
+            existing = [p['name'] for p in data['parameters'] if p['in'] == 'path']
             data["parameters"].extend(
                 {"in": "path", "name": path_key, "required": True, "type": "string"}
-                for path_key in get_path_keys(url_path)
+                for path_key in get_path_keys(url_path) if path_key not in existing
             )
             operations = copy.deepcopy(data)
             self.spec.add_path(Path(path=url_path, operations={method: operations}))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,6 +92,11 @@ def aiohttp_app(request_schema, request_callable_schema, loop, test_client, requ
         print(request.data)
         return web.json_response(request['data'])
 
+    @docs(parameters=[{'in': 'path', 'name': 'var', 'schema': {'type':'string', 'format':'uuid'}}])
+    def handler_get_variable(request):
+        print(request.data)
+        return web.json_response(request['data'])
+
     class ViewClass(web.View):
         @docs(
             tags=['mytag'],
@@ -129,6 +134,7 @@ def aiohttp_app(request_schema, request_callable_schema, loop, test_client, requ
                 web.view('/class_echo', ViewClass),
                 web.get('/echo_old', handler_get_echo_old_data),
                 web.post('/echo', handler_post_echo),
+                web.get('/variable/{var}', handler_get_variable),
             ]
         )
         v1.middlewares.append(validation_middleware)
@@ -147,6 +153,7 @@ def aiohttp_app(request_schema, request_callable_schema, loop, test_client, requ
                 web.view('/v1/class_echo', ViewClass),
                 web.get('/v1/echo_old', handler_get_echo_old_data),
                 web.post('/v1/echo', handler_post_echo),
+                web.get('/v1/variable/{var}', handler_get_variable),
             ]
         )
         app.middlewares.append(validation_middleware)

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -3,7 +3,13 @@ from yarl import URL
 
 
 def test_app_swagger_url(aiohttp_app):
-    urls = [route.url_for() for route in aiohttp_app.app.router.routes()]
+    def safe_url_for(route):
+        try:
+            return route.url_for()
+        except KeyError:
+            return None
+
+    urls = [safe_url_for(route) for route in aiohttp_app.app.router.routes()]
     assert URL('/v1/api/docs/api-docs') in urls
 
 

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -114,6 +114,16 @@ async def test_response_data_class_post(aiohttp_app):
     assert res.status == 405
 
 
+async def test_path_variable_described_correctly(aiohttp_app):
+    if aiohttp_app.app._subapps:
+        swag = aiohttp_app.app._subapps[0]["swagger_dict"]["paths"]["/v1/variable/{var}"]
+    else:
+        swag = aiohttp_app.app["swagger_dict"]["paths"]["/v1/variable/{var}"]
+    assert len(swag['get']['parameters']) == 1, "There should only be one"
+    assert swag['get']['parameters'][0]['name'] == 'var'
+    assert swag['get']['parameters'][0]['schema']['format'] == 'uuid'
+
+
 async def test_response_data_class_without_spec(aiohttp_app):
     res = await aiohttp_app.delete('/v1/class_echo')
     assert (await res.json()) == {'hello': 'world'}


### PR DESCRIPTION
This fixes issue #28 
Even if a path parameter was described with `@docs` or `@use_kwargs( locations=['path'] )` it will still get the default string property added by `_register()`

this adds a test for the issue and fixes it.