### PR TITLE
Rename use_kwargs -> request_schema and marshal_with -> response_schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@
 <p>
 
 ```aiohttp-apispec``` key features:
-- ```docs```, ```use_kwargs``` and ```marshal_with``` decorators 
-to add swagger spec support out of the box
+- ```docs```, ```request_schema``` and ```response_schema``` decorators 
+to add swagger spec support out of the box. You can also use 
+the ```use_kwags``` and ```marshal_with``` decorators 
+instead of ```request_schema``` and ```response_schema``` respectively.
 - ```validation_middleware``` middleware to enable validating 
 with marshmallow schemas from those decorators
 
@@ -47,7 +49,7 @@ pip install aiohttp-apispec
 ## Quickstart
 
 ```Python
-from aiohttp_apispec import docs, use_kwargs, marshal_with, setup_aiohttp_apispec
+from aiohttp_apispec import docs, request_schema, response_schema, setup_aiohttp_apispec
 from aiohttp import web
 from marshmallow import Schema, fields
 
@@ -65,8 +67,8 @@ class ResponseSchema(Schema):
 @docs(tags=["mytag"], 
       summary="Test method summary", 
       description="Test method description")
-@use_kwargs(RequestSchema(strict=True))
-@marshal_with(ResponseSchema(), 200)
+@request_schema(RequestSchema(strict=True))
+@response_schema(ResponseSchema(), 200)
 async def index(request):
     return web.json_response({"msg": "done", "data": {}})
 
@@ -88,8 +90,8 @@ class TheView(web.View):
         summary="View method summary",
         description="View method description",
     )
-    @use_kwargs(RequestSchema(strict=True))
-    @marshal_with(ResponseSchema(), 200)
+    @request_schema(RequestSchema(strict=True))
+    @response_schema(ResponseSchema(), 200)
     def delete(self):
         return web.json_response(
             {"msg": "done", "data": {"name": self.request["data"]["name"]}}
@@ -116,8 +118,8 @@ Now you can access all validated data in route from ```request['data']``` like s
     summary='Test method summary',
     description='Test method description',
 )
-@use_kwargs(RequestSchema(strict=True))
-@marshal_with(ResponseSchema(), 200)
+@request_schema(RequestSchema(strict=True))
+@response_schema(ResponseSchema(), 200)
 async def index(request):
     uid = request['data']['id']
     name = request['data']['name']
@@ -139,7 +141,7 @@ setup_aiohttp_apispec(app=app,
                       
 ...                  
 
-@use_kwargs(RequestSchema(strict=True))
+@request_schema(RequestSchema(strict=True))
 async def index(request):
     uid = request['validated_data']['id']
         ...

--- a/aiohttp_apispec/__init__.py
+++ b/aiohttp_apispec/__init__.py
@@ -1,10 +1,12 @@
 from .aiohttp_apispec import AiohttpApiSpec, setup_aiohttp_apispec
-from .decorators import docs, use_kwargs, marshal_with
+from .decorators import docs, request_schema, response_schema, use_kwargs, marshal_with
 from .middlewares import aiohttp_apispec_middleware, validation_middleware
 
 __all__ = [
     "setup_aiohttp_apispec",
     "docs",
+    "request_schema",
+    "response_schema",
     "use_kwargs",
     "marshal_with",
     "validation_middleware",

--- a/aiohttp_apispec/aiohttp_apispec.py
+++ b/aiohttp_apispec/aiohttp_apispec.py
@@ -124,7 +124,7 @@ def setup_aiohttp_apispec(
 
     .. code-block:: python
 
-        from aiohttp_apispec import docs, use_kwargs, setup_aiohttp_apispec
+        from aiohttp_apispec import docs, request_schema, setup_aiohttp_apispec
         from aiohttp import web
         from marshmallow import Schema, fields
 
@@ -138,7 +138,7 @@ def setup_aiohttp_apispec(
         @docs(tags=['mytag'],
               summary='Test method summary',
               description='Test method description')
-        @use_kwargs(RequestSchema)
+        @request_schema(RequestSchema)
         async def index(request):
             return web.json_response({'msg': 'done', 'data': {}})
 

--- a/aiohttp_apispec/decorators.py
+++ b/aiohttp_apispec/decorators.py
@@ -38,7 +38,7 @@ def docs(**kwargs):
     return wrapper
 
 
-def use_kwargs(schema, locations=None, **kwargs):
+def request_schema(schema, locations=None, **kwargs):
     """
     Add request info into the swagger spec and
     prepare injection keyword arguments from the specified
@@ -57,7 +57,7 @@ def use_kwargs(schema, locations=None, **kwargs):
             id = fields.Int()
             name = fields.Str(description='name')
 
-        @use_kwargs(RequestSchema(strict=True))
+        @request_schema(RequestSchema(strict=True))
         async def index(request):
             # aiohttp_apispec_middleware should be used for it
             data = request['data']
@@ -102,7 +102,10 @@ def use_kwargs(schema, locations=None, **kwargs):
     return wrapper
 
 
-def marshal_with(schema, code=200, required=False, description=None):
+use_kwargs = request_schema
+
+
+def response_schema(schema, code=200, required=False, description=None):
     """
     Add response info into the swagger spec
 
@@ -118,7 +121,7 @@ def marshal_with(schema, code=200, required=False, description=None):
             msg = fields.Str()
             data = fields.Dict()
 
-        @marshal_with(ResponseSchema(), 200)
+        @response_schema(ResponseSchema(), 200)
         async def index(request):
             return web.json_response({'msg': 'done', 'data': {}})
 
@@ -141,3 +144,6 @@ def marshal_with(schema, code=200, required=False, description=None):
         return func
 
     return wrapper
+
+
+marshal_with = response_schema

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@ Build and document REST APIs with aiohttp and apispec
 
 ``aiohttp-apispec`` key features:
 
-- ``docs``, ``use_kwargs`` and ``marshal_with`` decorators to add swagger spec support out of the box
+- ``docs``, ``request_schema`` and ``response_schema`` decorators to add swagger spec support out of the box
 
 - ``validation_middleware`` middleware to enable validating with marshmallow schemas from those decorators
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -9,8 +9,8 @@ Quickstart
 .. code-block:: python
 
     from aiohttp_apispec import (docs,
-                                 use_kwargs,
-                                 marshal_with,
+                                 request_schema,
+                                 response_schema,
                                  setup_aiohttp_apispec)
     from aiohttp import web
     from marshmallow import Schema, fields
@@ -30,8 +30,8 @@ Quickstart
     @docs(tags=['mytag'],
           summary='Test method summary',
           description='Test method description')
-    @use_kwargs(RequestSchema(strict=True))
-    @marshal_with(ResponseSchema(), 200)
+    @request_schema(RequestSchema(strict=True))
+    @response_schema(ResponseSchema(), 200)
     async def index(request):
         return web.json_response({'msg': 'done',
                                   'data': {}})
@@ -43,7 +43,7 @@ Quickstart
             summary='View method summary',
             description='View method description',
         )
-        @use_kwargs(RequestSchema(strict=True))
+        @request_schema(RequestSchema(strict=True))
         def delete(self):
             return web.json_response({
                 'msg': 'done',
@@ -80,8 +80,8 @@ Now you can access all validated data in route from ``request['data']`` like so:
     @docs(tags=['mytag'],
           summary='Test method summary',
           description='Test method description')
-    @use_kwargs(RequestSchema(strict=True))
-    @marshal_with(ResponseSchema(), 200)
+    @request_schema(RequestSchema(strict=True))
+    @response_schema(ResponseSchema(), 200)
     async def index(request):
         uid = request['data']['id']
         name = request['data']['name']
@@ -103,7 +103,7 @@ with ``request_data_name`` argument of ``setup_aiohttp_apispec`` function:
 
     ...
 
-    @use_kwargs(RequestSchema(strict=True))
+    @request_schema(RequestSchema(strict=True))
     async def index(request):
         uid = request['validated_data']['id']
         ...

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ from aiohttp import web
 from marshmallow import Schema, fields
 
 from aiohttp_apispec import (
-    use_kwargs,
+    request_schema,
     docs,
     validation_middleware,
     setup_aiohttp_apispec,
@@ -22,7 +22,7 @@ def pytest_report_header(config):
 
 
 @pytest.fixture
-def request_schema():
+def request_schema_fixture():
     class RequestSchema(Schema):
         id = fields.Int()
         name = fields.Str(description="name")
@@ -33,7 +33,7 @@ def request_schema():
 
 
 @pytest.fixture
-def request_callable_schema():
+def request_callable_schema_fixture():
     class RequestSchema(Schema):
         id = fields.Int()
         name = fields.Str(description="name")
@@ -44,7 +44,7 @@ def request_callable_schema():
 
 
 @pytest.fixture
-def response_schema():
+def response_schema_fixture():
     class ResponseSchema(Schema):
         msg = fields.Str()
         data = fields.Dict()
@@ -60,7 +60,7 @@ def response_schema():
         ({"location": "query"}, False),
     ]
 )
-def aiohttp_app(request_schema, request_callable_schema, loop, aiohttp_client, request):
+def aiohttp_app(request_schema_fixture, request_callable_schema_fixture, loop, aiohttp_client, request):
     locations, nested = request.param
 
     @docs(
@@ -68,26 +68,26 @@ def aiohttp_app(request_schema, request_callable_schema, loop, aiohttp_client, r
         summary="Test method summary",
         description="Test method description",
     )
-    @use_kwargs(request_schema, **locations)
+    @request_schema(request_schema_fixture, **locations)
     async def handler_get(request):
         print(request.data)
         return web.json_response({"msg": "done", "data": {}})
 
-    @use_kwargs(request_schema)
+    @request_schema(request_schema_fixture)
     async def handler_post(request):
         print(request.data)
         return web.json_response({"msg": "done", "data": {}})
 
-    @use_kwargs(request_callable_schema)
+    @request_schema(request_callable_schema_fixture)
     async def handler_post_callable_schema(request):
         print(request.data)
         return web.json_response({"msg": "done", "data": {}})
 
-    @use_kwargs(request_schema)
+    @request_schema(request_schema_fixture)
     async def handler_post_echo(request):
         return web.json_response(request["data"])
 
-    @use_kwargs(request_schema, **locations)
+    @request_schema(request_schema_fixture, **locations)
     async def handler_get_echo(request):
         print(request.data)
         return web.json_response(request["data"])
@@ -111,14 +111,14 @@ def aiohttp_app(request_schema, request_callable_schema, loop, aiohttp_client, r
             summary="View method summary",
             description="View method description",
         )
-        @use_kwargs(request_schema, **locations)
+        @request_schema(request_schema_fixture, **locations)
         async def get(self):
             return web.json_response(self.request["data"])
 
         async def delete(self):
             return web.json_response({"hello": "world"})
 
-    @use_kwargs(request_schema, **locations)
+    @request_schema(request_schema_fixture, **locations)
     async def handler_get_echo_old_data(request):
         print(request.data)
         return web.json_response(request.data)

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,19 +1,19 @@
 import pytest
 from aiohttp import web
 
-from aiohttp_apispec import docs, use_kwargs, marshal_with
+from aiohttp_apispec import docs, request_schema, response_schema
 
 
 class TestViewDecorators:
     @pytest.fixture
-    def aiohttp_view_all(self, request_schema, response_schema):
+    def aiohttp_view_all(self, request_schema_fixture, response_schema_fixture):
         @docs(
             tags=["mytag"],
             summary="Test method summary",
             description="Test method description",
         )
-        @use_kwargs(request_schema, locations=["query"])
-        @marshal_with(response_schema, 200)
+        @request_schema(request_schema_fixture, locations=["query"])
+        @response_schema(response_schema_fixture, 200)
         async def index(request, **data):
             return web.json_response({"msg": "done", "data": {}})
 
@@ -32,16 +32,16 @@ class TestViewDecorators:
         return index
 
     @pytest.fixture
-    def aiohttp_view_kwargs(self, request_schema):
-        @use_kwargs(request_schema, locations=["query"])
+    def aiohttp_view_kwargs(self, request_schema_fixture):
+        @request_schema(request_schema_fixture, locations=["query"])
         async def index(request, **data):
             return web.json_response({"msg": "done", "data": {}})
 
         return index
 
     @pytest.fixture
-    def aiohttp_view_marshal(self, response_schema):
-        @marshal_with(response_schema, 200, description="Method description")
+    def aiohttp_view_marshal(self, response_schema_fixture):
+        @response_schema(response_schema_fixture, 200, description="Method description")
         async def index(request, **data):
             return web.json_response({"msg": "done", "data": {}})
 
@@ -55,17 +55,17 @@ class TestViewDecorators:
         for param in ("parameters", "responses"):
             assert param in aiohttp_view_docs.__apispec__
 
-    def test_use_kwargs_view(self, aiohttp_view_kwargs, request_schema):
+    def test_request_schema_view(self, aiohttp_view_kwargs, request_schema_fixture):
         assert hasattr(aiohttp_view_kwargs, "__apispec__")
         assert hasattr(aiohttp_view_kwargs, "__schemas__")
         assert aiohttp_view_kwargs.__schemas__ == [
-            {"schema": request_schema, "locations": ["query"]}
+            {"schema": request_schema_fixture, "locations": ["query"]}
         ]
         for param in ("parameters", "responses"):
             assert param in aiohttp_view_kwargs.__apispec__
 
     @pytest.mark.skip
-    def test_use_kwargs_parameters(self, aiohttp_view_kwargs):
+    def test_request_schema_parameters(self, aiohttp_view_kwargs):
         parameters = aiohttp_view_kwargs.__apispec__["parameters"]
         print(sorted(parameters, key=lambda x: x["name"]))
         assert sorted(parameters, key=lambda x: x["name"]) == [
@@ -109,11 +109,11 @@ class TestViewDecorators:
         assert aiohttp_view_all.__apispec__["summary"] == "Test method summary"
         assert aiohttp_view_all.__apispec__["description"] == "Test method description"
 
-    def test_view_multiple_body_parameters(self, request_schema):
+    def test_view_multiple_body_parameters(self, request_schema_fixture):
         with pytest.raises(RuntimeError) as ex:
 
-            @use_kwargs(request_schema, locations=["body"])
-            @use_kwargs(request_schema, locations=["body"])
+            @request_schema(request_schema_fixture, locations=["body"])
+            @request_schema(request_schema_fixture, locations=["body"])
             async def index(request, **data):
                 return web.json_response({"msg": "done", "data": {}})
 


### PR DESCRIPTION
The decorators `use_kwargs` and `marshal_with` have been renamed to `request_schema` and `response_schema` respectively, but old names are alose supported for backward compability.