### PR TITLE
Bug fix for swagger UI when using long paths like "/docs/ui"

### DIFF
--- a/aiohttp_apispec/static/index.html
+++ b/aiohttp_apispec/static/index.html
@@ -4,9 +4,9 @@
   <head>
     <meta charset="UTF-8">
     <title>Swagger UI</title>
-    <link rel="stylesheet" type="text/css" href=".{{ static }}/swagger-ui.css" >
-    <link rel="icon" type="image/png" href=".{{ static }}/favicon-32x32.png" sizes="32x32" />
-    <link rel="icon" type="image/png" href=".{{ static }}/favicon-16x16.png" sizes="16x16" />
+    <link rel="stylesheet" type="text/css" href="{{ static }}/swagger-ui.css" >
+    <link rel="icon" type="image/png" href="{{ static }}/favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="{{ static }}/favicon-16x16.png" sizes="16x16" />
     <style>
       html
       {
@@ -33,8 +33,8 @@
   <body>
     <div id="swagger-ui"></div>
 
-    <script src=".{{ static }}/swagger-ui-bundle.js"> </script>
-    <script src=".{{ static }}/swagger-ui-standalone-preset.js"> </script>
+    <script src="{{ static }}/swagger-ui-bundle.js"> </script>
+    <script src="{{ static }}/swagger-ui-standalone-preset.js"> </script>
     <script>
     window.onload = function() {
       // Begin Swagger UI call region


### PR DESCRIPTION
When using swagger_path like "/docs/ui" instead of "/docs" the swagger page will show blank screen. The reason is that it fails to load CSS and JS files, which in turn happens because it tries to load them relatively from "/docs/static/..." instead of "/static".

I fixed this in swagger's index.html