### PR TITLE
Call open() with string instead of Path, for 3.5

### DIFF
--- a/aiohttp_apispec/aiohttp_apispec.py
+++ b/aiohttp_apispec/aiohttp_apispec.py
@@ -65,7 +65,7 @@ class AiohttpApiSpec:
         static_files = Path(__file__).parent / "static"
         app.router.add_static(static_path, static_files)
 
-        with open(static_files / "index.html") as swg_tmp:
+        with open(str(static_files / "index.html")) as swg_tmp:
             tmp = Template(swg_tmp.read()).render(path=self.url, static=static_path)
 
         async def swagger_view(_):


### PR DESCRIPTION
Fixes #44 

Explicitly convert the `Path` object used for the `open()` call to a
string representation of the file path, for compatibility with Python
3.5.
