### PR TITLE
feature: Support passing custom OpenAPI versions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@
 *.egg-info
 /dist
 /venv
+/.venv
 .mypy_cache/
 .DS_Store

--- a/aiohttp_apispec/aiohttp_apispec.py
+++ b/aiohttp_apispec/aiohttp_apispec.py
@@ -24,12 +24,12 @@ class AiohttpApiSpec:
         app=None,
         request_data_name="data",
         swagger_path=None,
-        static_path='/static/swagger',
+        static_path="/static/swagger",
         **kwargs
     ):
 
         self.plugin = MarshmallowPlugin()
-        self.spec = APISpec(plugins=(self.plugin,), openapi_version="2.0", **kwargs)
+        self.spec = APISpec(plugins=(self.plugin,), **kwargs)
 
         self.url = url
         self.swagger_path = swagger_path
@@ -61,7 +61,9 @@ class AiohttpApiSpec:
         if self.swagger_path is not None:
             self.add_swagger_web_page(app, self.static_path, self.swagger_path)
 
-    def add_swagger_web_page(self, app: web.Application, static_path: str, view_path: str):
+    def add_swagger_web_page(
+        self, app: web.Application, static_path: str, view_path: str
+    ):
         static_files = Path(__file__).parent / "static"
         app.router.add_static(static_path, static_files)
 
@@ -69,9 +71,7 @@ class AiohttpApiSpec:
             tmp = Template(swg_tmp.read()).render(path=self.url, static=static_path)
 
         async def swagger_view(_):
-            return web.Response(
-                text=tmp, content_type="text/html"
-            )
+            return web.Response(text=tmp, content_type="text/html")
 
         app.router.add_route("GET", view_path, swagger_view)
 
@@ -148,10 +148,11 @@ def setup_aiohttp_apispec(
     *,
     title: str = "API documentation",
     version: str = "0.0.1",
+    openapi_version: str = "2.0",
     url: str = "/api/docs/swagger.json",
     request_data_name: str = "data",
     swagger_path: str = None,
-    static_path: str = '/static/swagger',
+    static_path: str = "/static/swagger",
     **kwargs
 ) -> None:
     """
@@ -195,6 +196,7 @@ def setup_aiohttp_apispec(
     :param Application app: aiohttp web app
     :param str title: API title
     :param str version: API version
+    :param str openapi_version: OpenAPI version to use. By default: ``'2.0'``
     :param str url: url for swagger spec in JSON format
     :param str request_data_name: name of the key in Request object
                                   where validated data will be placed by
@@ -211,6 +213,7 @@ def setup_aiohttp_apispec(
         request_data_name,
         title=title,
         version=version,
+        openapi_version=openapi_version,
         swagger_path=swagger_path,
         static_path=static_path,
         **kwargs

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -2,6 +2,123 @@ import json
 from yarl import URL
 
 
+OPENAPI_20_V1_TEST_SCHEMA = {
+    "parameters": [
+        {"in": "query", "name": "bool_field", "required": False, "type": "boolean"},
+        {
+            "format": "int32",
+            "in": "query",
+            "name": "id",
+            "required": False,
+            "type": "integer",
+        },
+        {
+            "collectionFormat": "multi",
+            "in": "query",
+            "items": {"format": "int32", "type": "integer"},
+            "name": "list_field",
+            "required": False,
+            "type": "array",
+        },
+        {
+            "description": "name",
+            "in": "query",
+            "name": "name",
+            "required": False,
+            "type": "string",
+        },
+    ],
+    "responses": {
+        "200": {
+            "description": "Success response",
+            "schema": {"$ref": "#/definitions/Response"},
+        },
+        "404": {"description": "Not Found"},
+    },
+    "tags": ["mytag"],
+    "summary": "Test method summary",
+    "description": "Test method description",
+    "produces": ["application/json"],
+}
+
+OPENAPI_20_V1_CLASS_ECHO_SCHEMA = {
+    "parameters": [
+        {"in": "query", "name": "bool_field", "required": False, "type": "boolean"},
+        {
+            "format": "int32",
+            "in": "query",
+            "name": "id",
+            "required": False,
+            "type": "integer",
+        },
+        {
+            "collectionFormat": "multi",
+            "in": "query",
+            "items": {"format": "int32", "type": "integer"},
+            "name": "list_field",
+            "required": False,
+            "type": "array",
+        },
+        {
+            "description": "name",
+            "in": "query",
+            "name": "name",
+            "required": False,
+            "type": "string",
+        },
+    ],
+    "responses": {},
+    "tags": ["mytag"],
+    "summary": "View method summary",
+    "description": "View method description",
+    "produces": ["application/json"],
+}
+
+OPENAPI_20_DEFINITIONS_SCHEMA = {
+    "Response": {
+        "type": "object",
+        "properties": {"msg": {"type": "string"}, "data": {"type": "object"}},
+    },
+    "Request": {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string", "description": "name"},
+            "bool_field": {"type": "boolean"},
+            "list_field": {
+                "type": "array",
+                "items": {"type": "integer", "format": "int32"},
+            },
+            "id": {"type": "integer", "format": "int32"},
+        },
+    },
+    "Request1": {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string", "description": "name"},
+            "bool_field": {"type": "boolean"},
+            "list_field": {
+                "type": "array",
+                "items": {"type": "integer", "format": "int32"},
+            },
+            "id": {"type": "integer", "format": "int32"},
+        },
+    },
+}
+
+SCHEMAS_MAPPING = {
+    "2.0": (
+        OPENAPI_20_V1_TEST_SCHEMA,
+        OPENAPI_20_V1_CLASS_ECHO_SCHEMA,
+        OPENAPI_20_DEFINITIONS_SCHEMA,
+    ),
+    "2.1": (
+        OPENAPI_20_V1_TEST_SCHEMA,
+        OPENAPI_20_V1_CLASS_ECHO_SCHEMA,
+        OPENAPI_20_DEFINITIONS_SCHEMA,
+    ),
+}
+
+
 def test_app_swagger_url(aiohttp_app):
     def safe_url_for(route):
         try:
@@ -16,133 +133,30 @@ def test_app_swagger_url(aiohttp_app):
 async def test_app_swagger_json(aiohttp_app):
     resp = await aiohttp_app.get("/v1/api/docs/api-docs")
     docs = await resp.json()
+
     assert docs["info"]["title"] == "API documentation"
     assert docs["info"]["version"] == "0.0.1"
-    docs["paths"]["/v1/test"]["get"]["parameters"] = sorted(
-        docs["paths"]["/v1/test"]["get"]["parameters"], key=lambda x: x["name"]
-    )
-    assert json.dumps(docs["paths"]["/v1/test"]["get"], sort_keys=True) == json.dumps(
-        {
-            "parameters": [
-                {
-                    "in": "query",
-                    "name": "bool_field",
-                    "required": False,
-                    "type": "boolean",
-                },
-                {
-                    "format": "int32",
-                    "in": "query",
-                    "name": "id",
-                    "required": False,
-                    "type": "integer",
-                },
-                {
-                    "collectionFormat": "multi",
-                    "in": "query",
-                    "items": {"format": "int32", "type": "integer"},
-                    "name": "list_field",
-                    "required": False,
-                    "type": "array",
-                },
-                {
-                    "description": "name",
-                    "in": "query",
-                    "name": "name",
-                    "required": False,
-                    "type": "string",
-                },
-            ],
-            "responses": {
-                "200": {
-                    "description": "Success response",
-                    "schema": {"$ref": "#/definitions/Response"},
-                },
-                "404": {"description": "Not Found"},
-            },
-            "tags": ["mytag"],
-            "summary": "Test method summary",
-            "description": "Test method description",
-            "produces": ["application/json"],
-        },
-        sort_keys=True,
-    )
-    docs["paths"]["/v1/class_echo"]["get"]["parameters"] = sorted(
-        docs["paths"]["/v1/class_echo"]["get"]["parameters"], key=lambda x: x["name"]
-    )
-    assert json.dumps(
-        docs["paths"]["/v1/class_echo"]["get"], sort_keys=True
-    ) == json.dumps(
-        {
-            "parameters": [
-                {
-                    "in": "query",
-                    "name": "bool_field",
-                    "required": False,
-                    "type": "boolean",
-                },
-                {
-                    "format": "int32",
-                    "in": "query",
-                    "name": "id",
-                    "required": False,
-                    "type": "integer",
-                },
-                {
-                    "collectionFormat": "multi",
-                    "in": "query",
-                    "items": {"format": "int32", "type": "integer"},
-                    "name": "list_field",
-                    "required": False,
-                    "type": "array",
-                },
-                {
-                    "description": "name",
-                    "in": "query",
-                    "name": "name",
-                    "required": False,
-                    "type": "string",
-                },
-            ],
-            "responses": {},
-            "tags": ["mytag"],
-            "summary": "View method summary",
-            "description": "View method description",
-            "produces": ["application/json"],
-        },
-        sort_keys=True,
-    )
 
-    assert json.dumps(docs["definitions"], sort_keys=True) == json.dumps(
-        {
-            "Response": {
-                "type": "object",
-                "properties": {"msg": {"type": "string"}, "data": {"type": "object"}},
-            },
-            "Request": {
-                "type": "object",
-                "properties": {
-                    "name": {"type": "string", "description": "name"},
-                    "bool_field": {"type": "boolean"},
-                    "list_field": {
-                        "type": "array",
-                        "items": {"type": "integer", "format": "int32"},
-                    },
-                    "id": {"type": "integer", "format": "int32"},
-                },
-            },
-            "Request1": {
-                "type": "object",
-                "properties": {
-                    "name": {"type": "string", "description": "name"},
-                    "bool_field": {"type": "boolean"},
-                    "list_field": {
-                        "type": "array",
-                        "items": {"type": "integer", "format": "int32"},
-                    },
-                    "id": {"type": "integer", "format": "int32"},
-                },
-            },
-        },
-        sort_keys=True,
-    )
+    openapi_version = docs.get("openapi") or "2.0"
+    if openapi_version in SCHEMAS_MAPPING:
+        test_schema, class_echo_schema, definitions_schema = SCHEMAS_MAPPING[
+            openapi_version
+        ]
+        docs["paths"]["/v1/test"]["get"]["parameters"] = sorted(
+            docs["paths"]["/v1/test"]["get"]["parameters"], key=lambda x: x["name"]
+        )
+        assert json.dumps(
+            docs["paths"]["/v1/test"]["get"], sort_keys=True
+        ) == json.dumps(test_schema, sort_keys=True)
+
+        docs["paths"]["/v1/class_echo"]["get"]["parameters"] = sorted(
+            docs["paths"]["/v1/class_echo"]["get"]["parameters"],
+            key=lambda x: x["name"],
+        )
+        assert json.dumps(
+            docs["paths"]["/v1/class_echo"]["get"], sort_keys=True
+        ) == json.dumps(class_echo_schema, sort_keys=True)
+
+        assert json.dumps(docs["definitions"], sort_keys=True) == json.dumps(
+            definitions_schema, sort_keys=True
+        )


### PR DESCRIPTION
Previously `AiohttpApiSpec` instantiate `ApiSpec` only for `openapi_version == '2.0'`, this PR changes it by allowing pass `openapi_version` to `setup_aiohttp_apispec` function and then use given value, while instantiating `ApiSpec` instance.

Fixes #46