### PR TITLE
Allow to set content-type using docs decorator

### DIFF
--- a/aiohttp_apispec/decorators.py
+++ b/aiohttp_apispec/decorators.py
@@ -25,7 +25,8 @@ def docs(**kwargs):
     """
 
     def wrapper(func):
-        kwargs["produces"] = ["application/json"]
+        if not kwargs.get("produces"):
+            kwargs["produces"] = ["application/json"]
         if not hasattr(func, "__apispec__"):
             func.__apispec__ = {"parameters": [], "responses": {}}
         extra_parameters = kwargs.pop("parameters", [])


### PR DESCRIPTION
Currently, `produces` is forced to "application/json", which is clearly a
reasonable default value.

If the user sets it, pass it as-is to apispec.