### PR TITLE
Add the option for not register a docs route

### DIFF
--- a/aiohttp_apispec/aiohttp_apispec.py
+++ b/aiohttp_apispec/aiohttp_apispec.py
@@ -80,13 +80,14 @@ class AiohttpApiSpec:
 
         self._registered = True
 
-        async def swagger_handler(request):
-            return web.json_response(request.app["swagger_dict"])
+        if self.url is not None:
+            async def swagger_handler(request):
+                return web.json_response(request.app["swagger_dict"])
 
-        app.router.add_routes([web.get(self.url, swagger_handler)])
+            app.router.add_routes([web.get(self.url, swagger_handler)])
 
-        if self.swagger_path is not None:
-            self._add_swagger_web_page(app, self.static_path, self.swagger_path)
+            if self.swagger_path is not None:
+                self._add_swagger_web_page(app, self.static_path, self.swagger_path)
 
     def _add_swagger_web_page(
         self, app: web.Application, static_path: str, view_path: str

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -1,5 +1,7 @@
 import json
 
+from aiohttp import web
+from aiohttp_apispec import setup_aiohttp_apispec
 from yarl import URL
 
 
@@ -137,3 +139,11 @@ async def test_app_swagger_json(aiohttp_app):
         },
         sort_keys=True,
     )
+
+
+async def test_not_register_route_for_none_url():
+    app = web.Application()
+    routes_count = len(app.router.routes())
+    setup_aiohttp_apispec(app=app, url=None)
+    routes_count_after_setup_apispec = len(app.router.routes())
+    assert routes_count == routes_count_after_setup_apispec


### PR DESCRIPTION
In some cases I need possibilities doesn’t show docs for user even at json format. For example if docs is stored at different .yaml file.
This pr make aviable to pass explicit url=None and then route for docs will not registered.