### PR TITLE
Fix Response validation

### DIFF
--- a/aiohttp_apispec/decorators/response.py
+++ b/aiohttp_apispec/decorators/response.py
@@ -33,7 +33,7 @@ def response_schema(schema, code=200, required=False, description=None):
         func.__apispec__["responses"]["%s" % code] = {
             "schema": schema,
             "required": required,
-            "description": description,
+            "description": description or "",
         }
         return func
 


### PR DESCRIPTION
Fixes response validation error when the description is not provided.
When adding @response_schema annotation without description, output swagger json is not valid.