### PR TITLE
Bump aiohttp-apispec to 3.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read(file_name):
 
 setup(
     name='aiohttp-apispec',
-    version='2.2.2',
+    version='3.0.0',
     description='Build and document REST APIs with aiohttp and apispec',
     long_description=read('README.md'),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
I feel like major release should come after https://github.com/maximdanilchenko/aiohttp-apispec/pull/112 and https://github.com/maximdanilchenko/aiohttp-apispec/pull/115
