### PR TITLE
Fix isort commands, apply format fixes

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,6 +1,5 @@
 [settings]
 skip = venv
 multi_line_output = 3
-recursive = true
 include_trailing_comma = true
 line_length = 88

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,6 @@ matrix:
 install:
   - pip install -q -r dev-requirements.txt --no-cache-dir --upgrade
 script:
+  - make check_format
   - make test
 after_success: codecov

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,9 @@ upload:
 	twine upload dist/*
 
 format:
-	isort -y
-	black --target-version py35 .
+	isort .
+	black --target-version py36 .
 
 check_format:
-	isort --check --diff
+	isort . --check --diff
 	black . --check --diff

--- a/aiohttp_apispec/__init__.py
+++ b/aiohttp_apispec/__init__.py
@@ -1,16 +1,16 @@
 from .aiohttp_apispec import AiohttpApiSpec, setup_aiohttp_apispec
 from .decorators import (
+    cookies_schema,
     docs,
-    request_schema,
+    form_schema,
+    headers_schema,
+    json_schema,
+    marshal_with,
     match_info_schema,
     querystring_schema,
-    form_schema,
-    json_schema,
-    headers_schema,
-    cookies_schema,
+    request_schema,
     response_schema,
     use_kwargs,
-    marshal_with,
 )
 from .middlewares import validation_middleware
 

--- a/aiohttp_apispec/aiohttp_apispec.py
+++ b/aiohttp_apispec/aiohttp_apispec.py
@@ -1,5 +1,5 @@
-import os
 import copy
+import os
 from pathlib import Path
 from typing import Awaitable, Callable
 
@@ -48,7 +48,7 @@ class AiohttpApiSpec:
         in_place=False,
         prefix='',
         schema_name_resolver=resolver,
-        **kwargs
+        **kwargs,
     ):
 
         self.plugin = MarshmallowPlugin(schema_name_resolver=schema_name_resolver)
@@ -66,11 +66,11 @@ class AiohttpApiSpec:
             self.register(app, in_place)
 
     def swagger_dict(self):
-        """ Returns swagger spec representation in JSON format """
+        """Returns swagger spec representation in JSON format"""
         return self.spec.to_dict()
 
     def register(self, app: web.Application, in_place: bool = False):
-        """ Creates spec based on registered app routes and registers needed view """
+        """Creates spec based on registered app routes and registers needed view"""
         if self._registered is True:
             return None
 
@@ -92,13 +92,16 @@ class AiohttpApiSpec:
         self._registered = True
 
         if self.url is not None:
+
             async def swagger_handler(request):
                 return web.json_response(request.app["swagger_dict"])
 
             route_url = self.url
             if not self.url.startswith("/"):
                 route_url = "/{}".format(self.url)
-            app.router.add_route("GET", route_url, swagger_handler, name=NAME_SWAGGER_SPEC)
+            app.router.add_route(
+                "GET", route_url, swagger_handler, name=NAME_SWAGGER_SPEC
+            )
 
             if self.swagger_path is not None:
                 self._add_swagger_web_page(app, self.static_path, self.swagger_path)
@@ -111,10 +114,14 @@ class AiohttpApiSpec:
             url = self.url if app is None else app.router[NAME_SWAGGER_SPEC].url_for()
 
             if app is not None:
-                static_path = app.router[NAME_SWAGGER_STATIC].url_for(filename=INDEX_PAGE)
+                static_path = app.router[NAME_SWAGGER_STATIC].url_for(
+                    filename=INDEX_PAGE
+                )
                 static_path = os.path.dirname(str(static_path))
 
-            self._index_page = Template(swg_tmp.read()).render(path=url, static=static_path)
+            self._index_page = Template(swg_tmp.read()).render(
+                path=url, static=static_path
+            )
 
         return self._index_page
 
@@ -205,8 +212,11 @@ class AiohttpApiSpec:
             if add_to_refs:
                 self.spec.components.schemas[name]["example"] = example
             else:
-                endpoint_schema[0]['schema']['allOf'] = [endpoint_schema[0]['schema'].pop('$ref')]
+                endpoint_schema[0]['schema']['allOf'] = [
+                    endpoint_schema[0]['schema'].pop('$ref')
+                ]
                 endpoint_schema[0]['schema']["example"] = example
+
         if not example:
             return
         schema_instance = common.resolve_schema_instance(ref_schema)
@@ -232,7 +242,7 @@ def setup_aiohttp_apispec(
     in_place: bool = False,
     prefix: str = '',
     schema_name_resolver: Callable = resolver,
-    **kwargs
+    **kwargs,
 ) -> None:
     """
     aiohttp-apispec extension.
@@ -303,5 +313,5 @@ def setup_aiohttp_apispec(
         in_place=in_place,
         prefix=prefix,
         schema_name_resolver=schema_name_resolver,
-        **kwargs
+        **kwargs,
     )

--- a/aiohttp_apispec/decorators/__init__.py
+++ b/aiohttp_apispec/decorators/__init__.py
@@ -1,15 +1,12 @@
 from .docs import docs
 from .request import (
+    cookies_schema,
+    form_schema,
+    headers_schema,
+    json_schema,
+    match_info_schema,
+    querystring_schema,
     request_schema,
-    use_kwargs,  # for backward compatibility
-    match_info_schema,  # request_schema with locations=["match_info"]
-    querystring_schema,  # request_schema with locations=["querystring"]
-    form_schema,  # request_schema with locations=["form"]
-    json_schema,  # request_schema with locations=["json"]
-    headers_schema,  # request_schema with locations=["headers"]
-    cookies_schema,  # request_schema with locations=["cookies"]
+    use_kwargs,
 )
-from .response import (
-    response_schema,
-    marshal_with,  # for backward compatibility
-)
+from .response import marshal_with, response_schema

--- a/aiohttp_apispec/decorators/request.py
+++ b/aiohttp_apispec/decorators/request.py
@@ -1,6 +1,5 @@
-from functools import partial
 import copy
-
+from functools import partial
 
 # locations supported by both openapi and webargs.aiohttpparser
 VALID_SCHEMA_LOCATIONS = (
@@ -16,7 +15,9 @@ VALID_SCHEMA_LOCATIONS = (
 )
 
 
-def request_schema(schema, location="json", put_into=None, example=None, add_to_refs=False, **kwargs):
+def request_schema(
+    schema, location="json", put_into=None, example=None, add_to_refs=False, **kwargs
+):
     """
     Add request info into the swagger spec and
     prepare injection keyword arguments from the specified
@@ -71,18 +72,24 @@ def request_schema(schema, location="json", put_into=None, example=None, add_to_
         if _example:
             _example['add_to_refs'] = add_to_refs
         func.__apispec__["schemas"].append(
-            {"schema": schema, "location": location, "options": options, "example": _example}
+            {
+                "schema": schema,
+                "location": location,
+                "options": options,
+                "example": _example,
+            }
         )
 
         # TODO: Remove this block?
         # "body" location was replaced by "json" location
-        if (
-            location == "json" and
-            any(func_schema["location"] == "json" for func_schema in func.__schemas__)
+        if location == "json" and any(
+            func_schema["location"] == "json" for func_schema in func.__schemas__
         ):
             raise RuntimeError("Multiple json locations are not allowed")
 
-        func.__schemas__.append({"schema": schema, "location": location, "put_into": put_into})
+        func.__schemas__.append(
+            {"schema": schema, "location": location, "put_into": put_into}
+        )
 
         return func
 
@@ -94,14 +101,10 @@ use_kwargs = request_schema
 
 # Decorators for specific request data validations (shortenings)
 match_info_schema = partial(
-    request_schema,
-    location="match_info",
-    put_into="match_info"
+    request_schema, location="match_info", put_into="match_info"
 )
 querystring_schema = partial(
-    request_schema,
-    location="querystring",
-    put_into="querystring"
+    request_schema, location="querystring", put_into="querystring"
 )
 form_schema = partial(request_schema, location="form", put_into="form")
 json_schema = partial(request_schema, location="json", put_into="json")

--- a/aiohttp_apispec/middlewares.py
+++ b/aiohttp_apispec/middlewares.py
@@ -34,7 +34,7 @@ async def validation_middleware(request: web.Request, handler) -> web.Response:
             schema["schema"],
             request,
             location=schema["location"],
-            unknown=None # Pass None to use the schema’s setting instead.
+            unknown=None,  # Pass None to use the schema’s setting instead.
         )
         if schema["put_into"]:
             request[schema["put_into"]] = data

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
+black
 marshmallow
 pytest
 pytest-cov

--- a/example/views.py
+++ b/example/views.py
@@ -2,8 +2,7 @@
 from aiohttp import web
 
 from aiohttp_apispec import docs
-
-from aiohttp_apispec.decorators import json_schema, headers_schema, querystring_schema
+from aiohttp_apispec.decorators import headers_schema, json_schema, querystring_schema
 
 from .schemas import Message, User, UsersList
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,15 @@
 import pytest
 from aiohttp import web
-from marshmallow import Schema, fields, EXCLUDE, INCLUDE
+from marshmallow import EXCLUDE, INCLUDE, Schema, fields
 
 from aiohttp_apispec import (
+    cookies_schema,
     docs,
-    request_schema,
+    headers_schema,
+    json_schema,
     match_info_schema,
     querystring_schema,
-    json_schema,
-    headers_schema,
-    cookies_schema,
+    request_schema,
     response_schema,
     setup_aiohttp_apispec,
     validation_middleware,
@@ -19,6 +19,7 @@ from aiohttp_apispec import (
 class HeaderSchema(Schema):
     class Meta:
         unknown = EXCLUDE
+
     some_header = fields.String()
 
 
@@ -70,7 +71,7 @@ def example_for_request_schema():
         'name': 'test',
         'bool_field': True,
         'list_field': [1, 2, 3],
-        'nested_field': {'i': 12}
+        'nested_field': {'i': 12},
     }
 
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,6 +1,6 @@
 import pytest
 from aiohttp import web
-from marshmallow import fields, Schema
+from marshmallow import Schema, fields
 
 from aiohttp_apispec import docs, request_schema, response_schema
 
@@ -61,7 +61,9 @@ class TestViewDecorators:
         return index
 
     @pytest.fixture
-    def aiohttp_view_request_schema_with_example_without_refs(self, example_for_request_schema):
+    def aiohttp_view_request_schema_with_example_without_refs(
+        self, example_for_request_schema
+    ):
         @request_schema(RequestSchema, example=example_for_request_schema)
         async def index(request, **data):
             return web.json_response({"msg": "done", "data": {}})
@@ -70,7 +72,9 @@ class TestViewDecorators:
 
     @pytest.fixture
     def aiohttp_view_request_schema_with_example(self, example_for_request_schema):
-        @request_schema(RequestSchema, example=example_for_request_schema, add_to_refs=True)
+        @request_schema(
+            RequestSchema, example=example_for_request_schema, add_to_refs=True
+        )
         async def index(request, **data):
             return web.json_response({"msg": "done", "data": {}})
 
@@ -132,18 +136,20 @@ class TestViewDecorators:
         assert "200" in aiohttp_view_marshal.__apispec__["responses"]
 
     def test_request_schema_with_example_without_refs(
-            self,
-            aiohttp_view_request_schema_with_example_without_refs,
-            example_for_request_schema):
-        schema = aiohttp_view_request_schema_with_example_without_refs.__apispec__["schemas"][0]
+        self,
+        aiohttp_view_request_schema_with_example_without_refs,
+        example_for_request_schema,
+    ):
+        schema = aiohttp_view_request_schema_with_example_without_refs.__apispec__[
+            "schemas"
+        ][0]
         expacted_result = example_for_request_schema.copy()
         expacted_result['add_to_refs'] = False
         assert schema['example'] == expacted_result
 
     def test_request_schema_with_example(
-            self,
-            aiohttp_view_request_schema_with_example,
-            example_for_request_schema):
+        self, aiohttp_view_request_schema_with_example, example_for_request_schema
+    ):
         schema = aiohttp_view_request_schema_with_example.__apispec__["schemas"][0]
         expacted_result = example_for_request_schema.copy()
         expacted_result['add_to_refs'] = True

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -2,8 +2,9 @@ import json
 
 from aiohttp import web
 from aiohttp.web_urldispatcher import StaticResource
-from aiohttp_apispec import setup_aiohttp_apispec
 from yarl import URL
+
+from aiohttp_apispec import setup_aiohttp_apispec
 
 
 def test_app_swagger_url(aiohttp_app):
@@ -137,11 +138,9 @@ async def test_app_swagger_json(aiohttp_app, example_for_request_schema):
             'required': False,
             'name': 'body',
             'schema': {
-                'allOf': [
-                    {'$ref': '#/definitions/#/definitions/Request'}
-                ],
-                'example': example_for_request_schema
-            }
+                'allOf': [{'$ref': '#/definitions/#/definitions/Request'}],
+                'example': example_for_request_schema,
+            },
         }
     ]
 
@@ -154,7 +153,7 @@ async def test_app_swagger_json(aiohttp_app, example_for_request_schema):
                 "type": "array",
             },
             "name": {"description": "name", "type": "string"},
-            "nested_field": {"$ref": "#/definitions/MyNested"}
+            "nested_field": {"$ref": "#/definitions/MyNested"},
         },
         "type": "object",
     }

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -30,28 +30,33 @@ async def test_response_400_post(aiohttp_app):
         'text': 'Oops',
     }
 
+
 async def test_response_400_post_unknown_toplevel_field(aiohttp_app):
     # unknown_field is not a field in RequestSchema, default behavior is RAISE exception
-    res = await aiohttp_app.post("/v1/test", json={"id": 1, "name": "max", "unknown_field": "string"})
+    res = await aiohttp_app.post(
+        "/v1/test", json={"id": 1, "name": "max", "unknown_field": "string"}
+    )
     assert res.status == 400
     assert await res.json() == {
         'errors': {'json': {'unknown_field': ['Unknown field.']}},
         'text': 'Oops',
     }
 
+
 async def test_response_400_post_nested_fields(aiohttp_app):
     payload = {
-                'nested_field': {
-                    'i': 12,
-                    'j': 12, # unknown nested field
-                }
-            }
+        'nested_field': {
+            'i': 12,
+            'j': 12,  # unknown nested field
+        }
+    }
     res = await aiohttp_app.post("/v1/test", json=payload)
     assert res.status == 400
     assert await res.json() == {
         'errors': {'json': {'nested_field': {'j': ['Unknown field.']}}},
         'text': 'Oops',
     }
+
 
 async def test_response_not_docked(aiohttp_app):
     res = await aiohttp_app.get("/v1/other", params={"id": 1, "name": "max"})
@@ -175,11 +180,13 @@ async def test_validators(aiohttp_app):
         "match_info": {"uuid": 123456},
     }
 
+
 async def test_swagger_path(aiohttp_app):
     res = await aiohttp_app.get("/v1/api/docs")
     assert res.status == 200
 
 
 async def test_swagger_static(aiohttp_app):
-    assert (await aiohttp_app.get("/static/swagger/swagger-ui.css")).status == 200 \
-        or (await aiohttp_app.get("/v1/static/swagger/swagger-ui.css")).status == 200
+    assert (await aiohttp_app.get("/static/swagger/swagger-ui.css")).status == 200 or (
+        await aiohttp_app.get("/v1/static/swagger/swagger-ui.css")
+    ).status == 200


### PR DESCRIPTION
Relevant isort changes (introduced in [5.0.0](https://pycqa.github.io/isort/CHANGELOG.html#500-penny-july-4-2020)):

- `--apply` (`-y`) option has been removed as it is the default behaviour
- `--recursive` option has been removed

Changes to aiohttp-apispec:

- removed `recursive = true` from .isort.cfg
- removed `-y` option from Makefile
- added `.` for isort commands in order to start check from the current dir
- added black to dev-requirements.txt
- applied changes from `make format`
- removed comments from imports in [`aiohttp_apispec/decorators/__init__.py`](https://github.com/maximdanilchenko/aiohttp-apispec/blob/master/aiohttp_apispec/decorators/__init__.py) since they break vertical hanging indent and don't seem to be very helpful 
**NOTE:** I checked it with isort==4.3.21 and the behavior was the same: when the comment is present, isort puts appropriate import within a separate line
