### PR TITLE
Return AiohttpApiSpec for setup_aiohttp_apispec

### DIFF
--- a/aiohttp_apispec/aiohttp_apispec.py
+++ b/aiohttp_apispec/aiohttp_apispec.py
@@ -300,8 +300,10 @@ def setup_aiohttp_apispec(
     :param prefix: prefix to add to all registered routes
     :param schema_name_resolver: custom schema_name_resolver for MarshmallowPlugin.
     :param kwargs: any apispec.APISpec kwargs
+    :return: return instance of AiohttpApiSpec class
+    :rtype: AiohttpApiSpec
     """
-    AiohttpApiSpec(
+    return AiohttpApiSpec(
         url,
         app,
         request_data_name,


### PR DESCRIPTION
Added return instance of `AiohttpApiSpec` for `setup_aiohttp_apispec` for ability to access class methods after initialization