### PR TITLE
Fix return type for setup_aiohttp_apispec

### DIFF
--- a/aiohttp_apispec/aiohttp_apispec.py
+++ b/aiohttp_apispec/aiohttp_apispec.py
@@ -243,7 +243,7 @@ def setup_aiohttp_apispec(
     prefix: str = '',
     schema_name_resolver: Callable = resolver,
     **kwargs,
-) -> None:
+) -> AiohttpApiSpec:
     """
     aiohttp-apispec extension.
 


### PR DESCRIPTION
Now setup_aiohttp_apispec returns AiohttpApiSpec instance and we need to fix return type.